### PR TITLE
ci: add workflow for running e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,66 @@
+name: End-to-End Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 8
+
+    - name: Get pnpm store directory
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+    - name: Setup pnpm cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Build project
+      run: pnpm run build
+
+    - name: Install Playwright browsers
+      run: pnpm exec playwright install --with-deps
+
+    - name: Run Playwright tests
+      run: pnpm run test:e2e
+
+    - name: Upload Playwright report
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results
+        path: test-results/
+        retention-days: 30

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -46,6 +46,9 @@ jobs:
     - name: Install Playwright browsers
       run: pnpm exec playwright install --with-deps
 
+    - name: Run database migrations
+      run: pnpm exec wrangler d1 migrations apply silroad --local
+
     - name: Run Playwright tests
       run: pnpm run test:e2e
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
           ${{ runner.os }}-pnpm-store-
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: pnpm install
 
     - name: Build project
       run: pnpm run build

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -43,7 +43,19 @@ jobs:
     - name: Build project
       run: pnpm run build
 
+    - name: Get Playwright version
+      id: playwright-version
+      run: echo "version=$(pnpm list @playwright/test --depth=0 | grep @playwright/test | sed 's/.*@playwright\/test@//' | sed 's/ .*//')" >> $GITHUB_OUTPUT
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      id: playwright-cache
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
     - name: Install Playwright browsers
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
       run: pnpm exec playwright install --with-deps
 
     - name: Run database migrations


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate end-to-end (E2E) testing for the project. The workflow is triggered on pushes and pull requests to the `main` branch and includes steps for setting up the environment, installing dependencies, running tests, and uploading test reports and results.

**New E2E Test Workflow:**

* Added `.github/workflows/e2e-tests.yml` to define a CI workflow for running Playwright-based E2E tests on pushes and pull requests to `main`.

**Workflow Setup and Optimization:**

* Configures Node.js and pnpm environments, including caching for pnpm dependencies and Playwright browsers to speed up workflow execution.
* Installs dependencies, builds the project, and applies database migrations before running E2E tests.

**Test Execution and Reporting:**

* Runs Playwright E2E tests and uploads both the Playwright report and test results as workflow artifacts for later inspection.